### PR TITLE
Adding Windows Support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ URL: https://github.com/jbryer/ipeds
 BugReports: https://github.com/jbryer/ipeds/issues
 Depends:
     utils, RCurl, Hmisc, httr
+Imports: DBI, odbc
 Suggests:
     reshape2, ggplot2, scales, knitr, rmarkdown
 Description: The Integrated Postsecondary Education Data

--- a/R/download_IPEDS.R
+++ b/R/download_IPEDS.R
@@ -73,7 +73,12 @@ download_ipeds <- function(year = as.integer(format(Sys.Date(), '%Y')) - 1,
 						'Downloaded file: ', dest, '\n',
 						'File not found: ', accdb.file))
 		}
-	
+	xlsx.file <- c(Sys.glob(paste0(substr(dest,1,nchar(dest)-4),"//*.xlsx")),Sys.glob(paste0(substr(dest,1,nchar(dest)-4),"//*//*.xlsx")))[1]
+	if(!file.exists(xlsx.file)) {
+	  stop(paste0('Problem loading XLSX Documentation file.\n',
+	              'Downloaded file: ', dest, '\n',
+	              'File not found: ', xlsx.file))
+	}
 #Import Data from access, Windows version uses DBI and ODBC to query access files. 
 	if(.Platform$OS.type == 'windows'){
 	  #Windows based import of mdb files. Uses ODBC to connect. 
@@ -82,9 +87,18 @@ download_ipeds <- function(year = as.integer(format(Sys.Date(), '%Y')) - 1,
 	    escape_characters <- c(' ', '(', ')')
 	    for(i in escape_characters) {
 	      accdb.file <- gsub(i, paste0('\\', i), accdb.file, fixed = TRUE)
+	      xlsx.file <- gsub(i, paste0('\\', i), xlsx.file, fixed = TRUE)
 	    }
 	    #connection string
 	    con<-DBI::dbConnect(odbc::odbc(), .connection_string = paste0("Driver={Microsoft Access Driver (*.mdb, *.accdb)}; Dbq=",accdb.file,";"))
+	    #list al tables, and remove system tables from list
+	    TableList<-DBI::dbListTables(con)
+	    TableList<-TableList[!grepl("MSys",TableList)]
+	    #import all tables, and store in a list with name of table as list object name.
+	    
+	      tb<-list(valueset=DBI::dbGetQuery(con,paste0("Select * from [",TableList[grepl("valueset",TableList)][1],"]")))
+	    DBI::dbDisconnect(con)
+	    con<-DBI::dbConnect(odbc::odbc(), .connection_string = paste0("Driver={Microsoft Excel Driver (*.xls, *.xlsx, *.xlsm, *.xlsb)}; Dbq=",xlsx.file,";"))
 	    #list al tables, and remove system tables from list
 	    TableList<-DBI::dbListTables(con)
 	    TableList<-TableList[!grepl("MSys",TableList)]
@@ -96,6 +110,7 @@ download_ipeds <- function(year = as.integer(format(Sys.Date(), '%Y')) - 1,
 	      return(tb)
 	    }))
 	    DBI::dbDisconnect(con)
+	    db<-c(db,tb)
 	    save(db, file = paste0(dir, 'IPEDS', year.str, '.Rda'))
 	  }, error = function(e) {
 	    print('Error loading the MS Access database file.')

--- a/R/download_IPEDS.R
+++ b/R/download_IPEDS.R
@@ -78,32 +78,64 @@ download_ipeds <- function(year = as.integer(format(Sys.Date(), '%Y')) - 1,
 		}
 	}
 	
-	# Need to have mdtools installed. From the terminal (on Mac):	
-	# ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null 2> /dev/null
-	# brew install mdbtools
-	tryCatch({
-		# Characters in the file path that should be escaped before calling mdbtools
-		escape_characters <- c(' ', '(', ')')
-		for(i in escape_characters) {
-			accdb.file <- gsub(i, paste0('\\', i), accdb.file, fixed = TRUE)
-		}
-		db <- Hmisc::mdb.get(accdb.file, stringsAsFactors = FALSE)
-		save(db, file = paste0(dir, 'IPEDS', year.str, '.Rda'))
-	}, error = function(e) {
-		print('Error loading the MS Access database file. Make sure mdtools is installed.')
-		if(Sys.info()['sysname'] == 'Darwin') {
-			print('The following terminal commands will install mdtools on Mac systems:')
-			cat('ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null 2> /dev/null \n')
-			cat('brew install mdbtools \n')
-		}
-		print('Original Error:')
-		print(e)
-	})
+#Import Data from access, Windows version uses DBI and ODBC to query access files. 
+	if(.Platform$OS.type == 'windows'){
+	  #Windows based import of mdb files. Uses ODBC to connect. 
+	  tryCatch({
+	    # Characters in the file path that should be escaped before calling mdbtools
+	    escape_characters <- c(' ', '(', ')')
+	    for(i in escape_characters) {
+	      accdb.file <- gsub(i, paste0('\\', i), accdb.file, fixed = TRUE)
+	    }
+	    #connection string
+	    con<-DBI::dbConnect(odbc::odbc(), .connection_string = paste0("Driver={Microsoft Access Driver (*.mdb, *.accdb)}; Dbq=",accdb.file,";"))
+	    #list al tables, and remove system tables from list
+	    TableList<-DBI::dbListTables(con)
+	    TableList<-TableList[!grepl("MSys",TableList)]
+	    #import all tables, and store in a list with name of table as list object name.
+	    db<-do.call("c",lapply(TableList,function(x){
+	      tb<-list()
+	      tb[[x]]<-DBI::dbGetQuery(con,paste0("Select * from [",x,"]"))
+	      setNames(tb,x)
+	      return(tb)
+	    }))
+	    DBI::dbDisconnect(con)
+	    save(db, file = paste0(dir, 'IPEDS', year.str, '.Rda'))
+	  }, error = function(e) {
+	    print('Error loading the MS Access database file.')
+	    print('Use odbc::odbcListDataSources() to check for MS Access Database Driver.')
+	    print('If Missing, install from here: https://www.microsoft.com/en-us/download/details.aspx?id=54920')
+	    print('Architecture must match R version (64bit vs 32bit)')
+	    print(e)
+	  })}else{
+	    #*nix based version of MDB import
+	    # Need to have mdtools installed. From the terminal (on Mac):	
+	    # ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null 2> /dev/null
+	    # brew install mdbtools
+	    tryCatch({
+	      # Characters in the file path that should be escaped before calling mdbtools
+	      escape_characters <- c(' ', '(', ')')
+	      for(i in escape_characters) {
+	        accdb.file <- gsub(i, paste0('\\', i), accdb.file, fixed = TRUE)
+	      }
+	      db <- Hmisc::mdb.get(accdb.file, stringsAsFactors = FALSE)
+	      save(db, file = paste0(dir, 'IPEDS', year.str, '.Rda'))
+	    }, error = function(e) {
+	      print('Error loading the MS Access database file. Make sure mdtools is installed.')
+	      if(Sys.info()['sysname'] == 'Darwin') {
+	        print('The following terminal commands will install mdtools on Mac systems:')
+	        cat('ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null 2> /dev/null \n')
+	        cat('brew install mdbtools \n')
+	      }
+	      print('Original Error:')
+	      print(e)
+	    })
+	    
+	    if(cleanup) {
+	      unlink(dest)
+	      unlink(accdb.file)
+	    }
+	    
+	    invisible(TRUE)
+	  }}
 	
-	if(cleanup) {
-		unlink(dest)
-		unlink(accdb.file)
-	}
-	
-	invisible(TRUE)
-}

--- a/R/download_IPEDS.R
+++ b/R/download_IPEDS.R
@@ -65,18 +65,14 @@ download_ipeds <- function(year = as.integer(format(Sys.Date(), '%Y')) - 1,
 		message('Zip file already downloaded. Set force=TRUE to redownload.')
 	}
 	
-	unzip(dest, exdir = dir)
+	unzip(dest, exdir = paste0(substr(dest,1,nchar(dest)-4),"//"))
 	
-	accdb.file <- paste0(dir, 'IPEDS', (year - 1), sprintf("%02d",year %% 1000), '.accdb')
+	accdb.file <- c(Sys.glob(paste0(substr(dest,1,nchar(dest)-4),"//*.accdb")),Sys.glob(paste0(substr(dest,1,nchar(dest)-4),"//*//*.accdb")))[1]
 	if(!file.exists(accdb.file)) {
-		# Check to see if it is a sub directory of the ZIP file.
-		accdb.file <- paste0(tools::file_path_sans_ext(dest), '/IPEDS', (year - 1), sprintf("%02d",year %% 1000), '.accdb')
-		if(!file.exists(accdb.file)) {
 			stop(paste0('Problem loading MS Access database file.\n',
 						'Downloaded file: ', dest, '\n',
 						'File not found: ', accdb.file))
 		}
-	}
 	
 #Import Data from access, Windows version uses DBI and ODBC to query access files. 
 	if(.Platform$OS.type == 'windows'){

--- a/R/recode.R
+++ b/R/recode.R
@@ -12,7 +12,7 @@ recodeDirectory <- function(hd) {
 	hd$hloffer = recodeHighestLevelOfOffering(hd$hloffer)
 	hd$ugoffer = recodeUndergraduateOffering(hd$ugoffer)
 	hd$groffer = recodeGraduateOffering(hd$groffer)
-	hd$hdegofr1 = recodeHighestDegreeOffered(hd$hdegofr1)
+	hd$hdegofr1 = recodeHighestDegreeOffered(if(is.null(hd$hdegofr1[1])){hd$groffer}else{hd$hdegofr1})
 	hd$openpubl = recodeOpenPublic(hd$openpubl)
 	hd$pset4flg = recodeTitleIVIndicator(hd$pset4flg)
 	hd$instsize = recodeInstitutionSize(hd$instsize)

--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ To install the latest development version from Github use the
 remotes::install_github('jbryer/ipeds')
 ```
 
-This package requires [mdbtools](https://github.com/brianb/mdbtools).
+On Linux or Mac, this package requires [mdbtools](https://github.com/brianb/mdbtools).
 The following commands will install `mdbtools` on Mac:
 
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null 2> /dev/null \n')
     brew install mdbtools
+
+On Windows, this package requires the Microsoft Access ODBC Driver. This driver comes with Microsoft Access. If you do not have Microsoft Access installed, or the Architecture differs from R (32bit vs 64bit), you can install the stand alone driver from [Microsoft](https://www.microsoft.com/en-us/download/details.aspx?id=54920)
+
 
 #### Using the `ipeds` package
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The `ipeds_help` function will return the data dictionary for the given
 year.
 
 ``` r
-View(ipeds_help(2021))
+View(ipeds_help(year=2021))
 ```
 
 If the `table` parameter is specified, then the data dictionary for the


### PR DESCRIPTION
This adds windows support to the download_ipeds function.
The function uses the DBI and odbc libraries. 
Most windows users wont need to install anything, as the odbc drivers come with Microsoft Access. If a user does not have Microsoft Access, or the architecture of their Office install differs from their R install, they will need to install a stand alone driver from Microsoft from here: https://www.microsoft.com/en-us/download/details.aspx?id=54920

I read in some old issues discussions that users attempts to add windows support in the past took to long to function. DBI is significantly faster than the rodbc package they were using. On my machine, this function seems to take around 60 seconds after the download is finished to finish saving the rdata file. 